### PR TITLE
Fixes date format in Header.js

### DIFF
--- a/src/Messages/components/PosterFont/Header.js
+++ b/src/Messages/components/PosterFont/Header.js
@@ -6,7 +6,7 @@ import styles from "./Header.module.css";
 export default function({ time, owner }) {
   return (
     <div className={styles.header}>
-      {format(time, "hh:mm")} | {format(time, `d–MMM-YYYY`)} | {owner}
+      {format(time, "hh:mm")} | {format(time, `d–MMM-yyyy`)} | {owner}
     </div>
   );
 }


### PR DESCRIPTION
Hello! The Poster Font feature was erroring with a date format issue. 

I didn't see any guidelines for contributing to the project; let me know if you have any preference for the commit message, etc.